### PR TITLE
feat(client): show loader in view client  modal and render form on load

### DIFF
--- a/frontend/src/types/clients.ts
+++ b/frontend/src/types/clients.ts
@@ -10,4 +10,5 @@ export type ClientFormValues = {
 // & interseccion
 export type Client = ClientFormValues & {
   id_client: number;
+  isActive?: boolean;
 };


### PR DESCRIPTION
View modified client
There you go. Now, when viewing a client by ID, the modal displays a loader while the data loads and only renders the form when it's ready.
This solves the problem of having to close and reopen the modal.

feat(clients): toggle Enable/Disable with optimistic update and good cache.