### PR TITLE
Fix #226: [FRONTEND] Resolve stale data issue in product edit modal

### DIFF
--- a/frontend/src/hooks/useProducts.ts
+++ b/frontend/src/hooks/useProducts.ts
@@ -70,8 +70,14 @@ export const useUpdateProduct = () => {
       if (!token) throw new Error('No hay token de autenticación');
       return productService.updateProduct(id ?? 0, data, token);
     },
-    onSuccess: () => {
+    onSuccess: (_, variables) => {
       queryClient.invalidateQueries({ queryKey: ['products'] });
+
+      if (variables.id) {
+        queryClient.invalidateQueries({ queryKey: ['product', variables.id] });
+      }
+
+      queryClient.invalidateQueries({ queryKey: ['product'] });
     },
   });
 };
@@ -86,8 +92,11 @@ export const useDeleteProduct = () => {
       if (!ids || ids.length === 0) throw new Error('No hay IDs de productos a eliminar');
       return productService.deleteProduct(ids, token);
     },
-    onSuccess: () => {
+    onSuccess: (_, ids) => {
       queryClient.invalidateQueries({ queryKey: ['products'] });
+      ids.forEach((id) => {
+        queryClient.removeQueries({ queryKey: ['product', id] });
+      });
     },
   });
 };
@@ -102,8 +111,11 @@ export const useDeactivateProduct = () => {
       if (!ids || ids.length === 0) throw new Error('No hay IDs de productos a desactivar');
       return productService.deactivateProduct(ids, token);
     },
-    onSuccess: () => {
+    onSuccess: (_, ids) => {
       queryClient.invalidateQueries({ queryKey: ['products'] });
+      ids.forEach((id) => {
+        queryClient.invalidateQueries({ queryKey: ['product', id] });
+      });
     },
   });
 };


### PR DESCRIPTION
# Fix: Resolve stale data issue in product edit modal

## Problem

The product edit modal was displaying outdated information when opened after making changes to products. This occurred because React Query's cache invalidation strategy was incomplete - only the general products list was being invalidated, but individual product queries remained stale.

## Solution

Enhanced cache invalidation strategy in product mutation hooks to ensure data consistency across all queries:

### Changes made:
- **`useUpdateProduct`**: Now invalidates both the products list and the specific product query
- **`useDeleteProduct`**: Uses `removeQueries` to completely remove deleted products from cache
- **`useDeactivateProduct`**: Invalidates individual product queries for each affected product

## Files changed

- `frontend/src/hooks/useProducts.ts` - Enhanced cache invalidation in mutation hooks

Closes #226 