### PR TITLE
fix 500 internal server error

### DIFF
--- a/frontend/src/api/clientService.ts
+++ b/frontend/src/api/clientService.ts
@@ -2,16 +2,15 @@ import axios, { AxiosError } from 'axios';
 import { API_BASE_URL } from '../lib/baseurl';
 import type { Client, ClientFormValues } from '../types/clients';
 
-export const getAllClients = async (id_user: number, token: string): Promise<Client[]> => {
+export const getAllClients = async (token: string): Promise<Client[]> => {
   try {
-    const { data } = await axios.get(`${API_BASE_URL}client/user/${id_user}`, {
+    const { data } = await axios.get(`${API_BASE_URL}client`, {
       headers: { Authorization: `Bearer ${token}` },
-      withCredentials: true,
     });
     return data;
   } catch (err) {
     const e = err as AxiosError;
-    console.error('[getAllClientsByUser] Error:', e.response?.data ?? e.message);
+    console.error('[getAllClients] Error:', e.response?.data ?? e.message);
     throw err;
   }
 };
@@ -20,7 +19,6 @@ export const getClientById = async (id_user: number, token: string): Promise<Cli
   try {
     const { data } = await axios.get(`${API_BASE_URL}client/${id_user}`, {
       headers: { Authorization: `Bearer ${token}` },
-      withCredentials: true,
     });
     return data;
   } catch (err) {
@@ -34,7 +32,6 @@ export const createClient = async (payload: ClientFormValues, token: string): Pr
   try {
     const { data } = await axios.post(`${API_BASE_URL}client/createclient`, payload, {
       headers: { Authorization: `Bearer ${token}` },
-      withCredentials: true,
     });
     return data;
   } catch (err) {
@@ -52,7 +49,6 @@ export const editClient = async (
   try {
     const { data } = await axios.put(`${API_BASE_URL}client/${id_user}`, payload, {
       headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
-      withCredentials: true,
     });
     return data;
   } catch (err) {
@@ -66,7 +62,6 @@ export const deleteClient = async (id_user: number, token: string): Promise<Clie
   try {
     const { data } = await axios.delete(`${API_BASE_URL}client/${id_user}`, {
       headers: { Authorization: `Bearer ${token}` },
-      withCredentials: true,
     });
     return data;
   } catch (err) {
@@ -83,7 +78,6 @@ export const deactivateClient = async (id_client: number, token: string): Promis
       {},
       {
         headers: { Authorization: `Bearer ${token}` },
-        withCredentials: true,
       }
     );
     return data;

--- a/frontend/src/hooks/useClient.ts
+++ b/frontend/src/hooks/useClient.ts
@@ -8,7 +8,7 @@ export const useGetAllClients = (id_user?: number) => {
   return useQuery<Client[], Error>({
     queryKey: ['clients', id_user],
     enabled: !!token && typeof id_user === 'number',
-    queryFn: () => clientService.getAllClients(id_user!, token!),
+    queryFn: () => clientService.getAllClients(token!),
     staleTime: 2 * 60 * 1000,
     retry: 1,
     refetchOnWindowFocus: false,

--- a/frontend/src/hooks/useDebtDashboardTotals.ts
+++ b/frontend/src/hooks/useDebtDashboardTotals.ts
@@ -7,7 +7,7 @@ export function useDebtDashboardTotals(id_user?: number, token?: string | null) 
     queryKey: ['debtDashboard', id_user, token],
     enabled: !!token && !!id_user,
     queryFn: async () => {
-      const clients: Client[] = await clientService.getAllClients(id_user!, token!);
+      const clients: Client[] = await clientService.getAllClients(token!);
       let totalOutstanding = 0;
       let totalNew = 0;
       let totalOld = 0;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,4 +1,4 @@
-// import './lib/axiosInterceptor';
+import './lib/axiosInterceptor';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,4 +1,4 @@
-import './lib/axiosInterceptor';
+// import './lib/axiosInterceptor';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -6,7 +6,6 @@ import './index.css';
 import App from './App.tsx';
 import { Provider } from 'react-redux';
 import { store } from './app/store';
-import './lib/axiosInterceptor';
 
 const queryClient = new QueryClient();
 


### PR DESCRIPTION
An authentication issue on the frontend caused by the unnecessary use of the withCredentials: true option in Axios requests was resolved. The backend uses token authentication in the header and does not require cookies, so withCredentials was removed from client services. This allowed requests to function correctly both locally and in production, avoiding 401 errors and CORS issues. 
A 500 intersal server error caused by a backend endpoint change was also resolved.